### PR TITLE
Fixed warning signed char forcing value to bool

### DIFF
--- a/test_spuce/test_cic.cpp
+++ b/test_spuce/test_cic.cpp
@@ -17,7 +17,7 @@ int main(int argv, char* argc[]) {
 	std::vector<double> y(N);
 
   imp = 1;
-	signed char dump = 1;
+	bool dump = true;
   for (i=0;i<N;i++) {
 		dump = ((i % rate) == 0);
     y[i] = (F.interpolate(imp, dump))*pow(rate,-O);


### PR DESCRIPTION
I was seeing this MSVC 2015, and since warnings were treated as errors, I usually just disabled examples. But this properly fixes the error since the type for dump should actually be bool.